### PR TITLE
Switch to mainworld2 in editor

### DIFF
--- a/Assets/Scenes/SceneNames.cs
+++ b/Assets/Scenes/SceneNames.cs
@@ -33,6 +33,7 @@ namespace Scenes
         public const string Help = "25-HelpScene";  //
         public const string Story = "26-Cutscene";  //
         public const string Settings = "28-SettingsScene"; //
+        public const string MainTwo = "21-MainWorldTwo";
 
         // NPC and interaction scenes
         public const string NPCInteractions = "30-NPCInteractionScene"; // might be split out

--- a/Assets/Scenes/SwitchScenes.cs
+++ b/Assets/Scenes/SwitchScenes.cs
@@ -1,3 +1,4 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -6,7 +7,15 @@ namespace Scenes
     public class SwitchScenes : MonoBehaviour
     {
         public static void SwitchToLogin() => SceneManager.LoadScene(SceneNames.Login);
-        public static void SwitchToMainWorld() => SceneLoader.Instance.LoadScene(SceneNames.Main);
+        public static void SwitchToMainWorld()
+        {
+            bool inEditor = false;
+#if UNITY_EDITOR
+            inEditor = true;
+#endif
+            if(inEditor) SceneLoader.Instance.LoadScene(SceneNames.MainTwo);
+            else SceneLoader.Instance.LoadScene(SceneNames.Main);
+        }
         public static void SwitchToPlayerHouseScene() => SceneLoader.Instance.LoadScene(SceneNames.House);
         public static void SwitchToWordFactoryLoadingScene() => SceneLoader.Instance.LoadScene(SceneNames.FactoryLoading);
         public static void SwitchToArcadeAsteroidScene() => SceneManager.LoadScene(SceneNames.ArcadeAsteroid);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new scene name, "21-MainWorldTwo," for enhanced gameplay options.

- **Improvements**
	- Updated scene-switching logic to load different scenes based on whether the application is running in the Unity Editor, improving development flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->